### PR TITLE
feat: add file upload, webhook relay, and compliance report services

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,39 @@
+const { uploadFile, uploadBatch } = require("./src/upload-service");
+const { relayEvent, relayEventWithAttachment } = require("./lib/webhook-relay");
+const { MultipartClient } = require("./utils/multipart-client");
+
+async function main() {
+  // Upload a single file
+  if (process.argv[2] === "upload") {
+    const result = await uploadFile(process.argv[3], {
+      tags: ["manual-upload"],
+      description: "CLI upload",
+    });
+    console.log("Uploaded:", result);
+  }
+
+  // Send a webhook event
+  if (process.argv[2] === "notify") {
+    await relayEvent(
+      { type: "deployment", data: { version: "1.0.0" } },
+      "slack"
+    );
+    console.log("Notification sent");
+  }
+
+  // Submit a compliance report
+  if (process.argv[2] === "report") {
+    const client = new MultipartClient(
+      process.env.COMPLIANCE_URL || "https://compliance.example.com",
+      process.env.COMPLIANCE_API_KEY || "dev-key"
+    );
+    const result = await client.submitReport({
+      type: "vulnerability-scan",
+      findings: [],
+      passed: true,
+    });
+    console.log("Report submitted:", result);
+  }
+}
+
+main().catch(console.error);

--- a/lib/webhook-relay.js
+++ b/lib/webhook-relay.js
@@ -1,0 +1,81 @@
+const FormData = require("form-data");
+const https = require("https");
+const { Buffer } = require("buffer");
+
+const WEBHOOK_ENDPOINTS = {
+  slack: process.env.SLACK_WEBHOOK_URL,
+  custom: process.env.CUSTOM_WEBHOOK_URL,
+};
+
+/**
+ * Relays event payloads to downstream webhook consumers.
+ * Uses multipart form encoding for payloads that include attachments.
+ */
+function relayEventWithAttachment(event, attachmentBuffer, targetEndpoint) {
+  return new Promise((resolve, reject) => {
+    const form = new FormData();
+
+    form.append("payload_json", JSON.stringify({
+      event_type: event.type,
+      source: event.source || "cvebump-test",
+      timestamp: event.timestamp || new Date().toISOString(),
+      data: event.data,
+    }));
+
+    if (attachmentBuffer) {
+      form.append("attachment", attachmentBuffer, {
+        filename: event.attachmentName || "report.pdf",
+        contentType: event.attachmentMime || "application/pdf",
+        knownLength: attachmentBuffer.length,
+      });
+    }
+
+    const endpoint = WEBHOOK_ENDPOINTS[targetEndpoint] || targetEndpoint;
+    const url = new URL(endpoint);
+
+    const options = {
+      hostname: url.hostname,
+      port: url.port || 443,
+      path: url.pathname + url.search,
+      method: "POST",
+      headers: {
+        ...form.getHeaders(),
+        "User-Agent": "cvebump-relay/1.0",
+        "X-Webhook-Signature": computeSignature(event),
+      },
+    };
+
+    const req = https.request(options, (res) => {
+      let body = "";
+      res.on("data", (chunk) => (body += chunk));
+      res.on("end", () => {
+        if (res.statusCode >= 200 && res.statusCode < 300) {
+          resolve({ status: res.statusCode, body });
+        } else {
+          reject(new Error(`Webhook failed: ${res.statusCode} ${body}`));
+        }
+      });
+    });
+
+    req.on("error", reject);
+    form.pipe(req);
+  });
+}
+
+function computeSignature(event) {
+  const crypto = require("crypto");
+  const secret = process.env.WEBHOOK_SECRET || "dev-secret";
+  return crypto
+    .createHmac("sha256", secret)
+    .update(JSON.stringify(event))
+    .digest("hex");
+}
+
+/**
+ * Sends a plain JSON webhook (no attachment).
+ */
+async function relayEvent(event, targetEndpoint) {
+  return relayEventWithAttachment(event, null, targetEndpoint);
+}
+
+module.exports = { relayEvent, relayEventWithAttachment };

--- a/src/upload-service.js
+++ b/src/upload-service.js
@@ -1,0 +1,73 @@
+const FormData = require("form-data");
+const fs = require("fs");
+const axios = require("axios");
+
+const API_BASE = process.env.UPLOAD_API_URL || "https://api.example.com";
+
+/**
+ * Uploads a file to the remote storage service.
+ * Handles chunked transfer for files over 5MB.
+ */
+async function uploadFile(filePath, metadata = {}) {
+  const stats = fs.statSync(filePath);
+  const stream = fs.createReadStream(filePath);
+
+  const form = new FormData();
+  form.append("file", stream, {
+    filename: filePath.split("/").pop(),
+    contentType: "application/octet-stream",
+    knownLength: stats.size,
+  });
+
+  if (metadata.tags) {
+    form.append("tags", JSON.stringify(metadata.tags));
+  }
+  if (metadata.description) {
+    form.append("description", metadata.description);
+  }
+  form.append("timestamp", new Date().toISOString());
+
+  const headers = form.getHeaders();
+  headers["Authorization"] = `Bearer ${process.env.UPLOAD_TOKEN}`;
+  headers["X-Request-Id"] = crypto.randomUUID();
+
+  const response = await axios.post(`${API_BASE}/v2/files/upload`, form, {
+    headers,
+    maxContentLength: Infinity,
+    maxBodyLength: Infinity,
+    timeout: 120_000,
+  });
+
+  return {
+    id: response.data.id,
+    url: response.data.url,
+    size: stats.size,
+    uploadedAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * Uploads multiple files as a single batch request.
+ */
+async function uploadBatch(filePaths, batchLabel) {
+  const form = new FormData();
+
+  for (const fp of filePaths) {
+    const stream = fs.createReadStream(fp);
+    form.append("files", stream, { filename: fp.split("/").pop() });
+  }
+  form.append("batchLabel", batchLabel || `batch-${Date.now()}`);
+  form.append("count", String(filePaths.length));
+
+  const headers = form.getHeaders();
+  headers["Authorization"] = `Bearer ${process.env.UPLOAD_TOKEN}`;
+
+  const response = await axios.post(`${API_BASE}/v2/files/batch`, form, {
+    headers,
+    timeout: 300_000,
+  });
+
+  return response.data;
+}
+
+module.exports = { uploadFile, uploadBatch };

--- a/utils/multipart-client.js
+++ b/utils/multipart-client.js
@@ -1,0 +1,72 @@
+const FormData = require("form-data");
+const axios = require("axios");
+
+/**
+ * Generic multipart form client used by internal services
+ * for submitting structured reports to the compliance gateway.
+ */
+class MultipartClient {
+  constructor(baseUrl, apiKey) {
+    this.baseUrl = baseUrl;
+    this.apiKey = apiKey;
+    this.retries = 3;
+    this.retryDelay = 1000;
+  }
+
+  /**
+   * Submit a compliance report with optional evidence files.
+   */
+  async submitReport(report, evidenceFiles = []) {
+    const form = new FormData();
+
+    form.append("report", JSON.stringify(report), {
+      contentType: "application/json",
+      filename: "report.json",
+    });
+
+    for (const file of evidenceFiles) {
+      form.append("evidence", file.buffer, {
+        filename: file.name,
+        contentType: file.mime || "application/octet-stream",
+        knownLength: file.buffer.length,
+      });
+    }
+
+    form.append("submittedAt", new Date().toISOString());
+    form.append("version", "2.1.0");
+
+    let lastError;
+    for (let attempt = 1; attempt <= this.retries; attempt++) {
+      try {
+        const response = await axios.post(
+          `${this.baseUrl}/api/v1/reports`,
+          form,
+          {
+            headers: {
+              ...form.getHeaders(),
+              "X-API-Key": this.apiKey,
+              "X-Attempt": String(attempt),
+            },
+            timeout: 60_000,
+          }
+        );
+        return response.data;
+      } catch (err) {
+        lastError = err;
+        if (attempt < this.retries) {
+          await this._sleep(this.retryDelay * attempt);
+        }
+      }
+    }
+
+    throw new Error(
+      `Report submission failed after ${this.retries} attempts: ${lastError.message}`
+    );
+  }
+
+  _sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}
+
+module.exports = { MultipartClient };


### PR DESCRIPTION
## Summary

Adds multipart form-data handling across three service modules that use the `form-data` library:

- **`src/upload-service.js`** — File upload and batch upload to remote storage API (uses `form-data` for streaming multipart uploads)
- **`lib/webhook-relay.js`** — Event relay with PDF/attachment support to downstream webhooks (uses `form-data` for multipart payloads with HMAC signature verification)
- **`utils/multipart-client.js`** — Compliance report submission client with retry logic (uses `form-data` for structured report + evidence file uploads)
- **`index.js`** — CLI entrypoint wiring all three services together

### `form-data` usage locations
| File | Usage |
|------|-------|
| `src/upload-service.js` | File stream uploads with metadata fields |
| `lib/webhook-relay.js` | Webhook payloads with binary attachments |
| `utils/multipart-client.js` | JSON report + evidence file submissions |