### PR TITLE
feat: add vulnerability feed, dependency health checker, and registry mirror

### DIFF
--- a/src/clients/vulnerability-feed.js
+++ b/src/clients/vulnerability-feed.js
@@ -1,0 +1,87 @@
+const axios = require("axios");
+
+const OSV_API = "https://api.osv.dev/v1";
+const NVD_API = "https://services.nvd.nist.gov/rest/json/cves/2.0";
+
+/**
+ * Fetches vulnerability advisories from multiple upstream feeds
+ * and normalises them into a common internal format.
+ */
+class VulnerabilityFeedClient {
+  constructor(opts = {}) {
+    this.nvdApiKey = opts.nvdApiKey || process.env.NVD_API_KEY;
+    this.timeout = opts.timeout || 15_000;
+    this.client = axios.create({
+      timeout: this.timeout,
+      headers: {
+        "User-Agent": "cvebump-feed/1.0",
+        Accept: "application/json",
+      },
+    });
+  }
+
+  /**
+   * Query OSV for advisories matching a package URL.
+   */
+  async queryOSV(purl) {
+    const response = await this.client.post(`${OSV_API}/query`, {
+      package: { purl },
+    });
+    const vulns = response.data.vulns || [];
+    return vulns.map((v) => this._normalise(v, "osv"));
+  }
+
+  /**
+   * Query NVD by CVE ID with optional API-key rate boost.
+   */
+  async queryNVD(cveId) {
+    const params = { cveId };
+    const headers = {};
+    if (this.nvdApiKey) {
+      headers["apiKey"] = this.nvdApiKey;
+    }
+
+    const response = await this.client.get(NVD_API, { params, headers });
+    const items = response.data.vulnerabilities || [];
+    return items.map((item) => this._normalise(item.cve, "nvd"));
+  }
+
+  /**
+   * Aggregate advisories from all configured feeds for a single package.
+   */
+  async aggregateAdvisories(purl, cveId) {
+    const [osvResults, nvdResults] = await Promise.allSettled([
+      this.queryOSV(purl),
+      cveId ? this.queryNVD(cveId) : Promise.resolve([]),
+    ]);
+
+    const advisories = [];
+    if (osvResults.status === "fulfilled") advisories.push(...osvResults.value);
+    if (nvdResults.status === "fulfilled") advisories.push(...nvdResults.value);
+
+    return {
+      purl,
+      cveId,
+      advisories,
+      sources: advisories.reduce((acc, a) => {
+        acc[a.source] = (acc[a.source] || 0) + 1;
+        return acc;
+      }, {}),
+      fetchedAt: new Date().toISOString(),
+    };
+  }
+
+  _normalise(raw, source) {
+    return {
+      id: raw.id || raw.cveId || raw.ID,
+      source,
+      severity: raw.severity || raw.metrics?.cvssMetricV31?.[0]?.cvssData?.baseSeverity || "UNKNOWN",
+      summary: raw.summary || raw.descriptions?.[0]?.value || "",
+      aliases: raw.aliases || [],
+      published: raw.published || raw.datePublished,
+      modified: raw.modified || raw.lastModified,
+    };
+  }
+}
+
+module.exports = { VulnerabilityFeedClient };

--- a/src/health/dependency-checker.js
+++ b/src/health/dependency-checker.js
@@ -1,0 +1,94 @@
+const axios = require("axios");
+const fs = require("fs");
+const path = require("path");
+
+const REGISTRY_URL = "https://registry.npmjs.org";
+
+/**
+ * Checks the health and freshness of project dependencies
+ * by querying the npm registry for each package.
+ */
+class DependencyHealthChecker {
+  constructor(projectRoot) {
+    this.projectRoot = projectRoot;
+    this.httpClient = axios.create({
+      baseURL: REGISTRY_URL,
+      timeout: 10_000,
+      headers: { Accept: "application/json" },
+    });
+  }
+
+  /**
+   * Reads package.json and returns merged deps + devDeps.
+   */
+  _loadDependencies() {
+    const pkgPath = path.join(this.projectRoot, "package.json");
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8"));
+    return {
+      ...pkg.dependencies,
+      ...pkg.devDependencies,
+    };
+  }
+
+  /**
+   * Queries the npm registry for latest version, deprecation status,
+   * and last-publish date for a single package.
+   */
+  async checkPackage(name, currentVersion) {
+    const response = await this.httpClient.get(`/${encodeURIComponent(name)}`);
+    const data = response.data;
+    const latest = data["dist-tags"]?.latest;
+    const latestInfo = data.versions?.[latest] || {};
+    const currentInfo = data.versions?.[currentVersion] || {};
+
+    return {
+      name,
+      currentVersion,
+      latestVersion: latest,
+      isOutdated: latest !== currentVersion,
+      isDeprecated: !!currentInfo.deprecated,
+      deprecationMessage: currentInfo.deprecated || null,
+      lastPublished: data.time?.[latest] || null,
+      daysSincePublish: data.time?.[latest]
+        ? Math.floor((Date.now() - new Date(data.time[latest]).getTime()) / 86400000)
+        : null,
+      license: latestInfo.license || "UNKNOWN",
+    };
+  }
+
+  /**
+   * Run a full health check across all dependencies.
+   */
+  async runFullCheck() {
+    const deps = this._loadDependencies();
+    const entries = Object.entries(deps);
+    const results = [];
+    const errors = [];
+
+    for (const [name, version] of entries) {
+      try {
+        const report = await this.checkPackage(name, version.replace(/^[\^~]/, ""));
+        results.push(report);
+      } catch (err) {
+        errors.push({ name, version, error: err.message });
+      }
+    }
+
+    const outdatedCount = results.filter((r) => r.isOutdated).length;
+    const deprecatedCount = results.filter((r) => r.isDeprecated).length;
+
+    return {
+      totalDependencies: entries.length,
+      checked: results.length,
+      outdated: outdatedCount,
+      deprecated: deprecatedCount,
+      errors: errors.length,
+      healthScore: Math.round(((results.length - outdatedCount - deprecatedCount) / entries.length) * 100),
+      results,
+      errors,
+      checkedAt: new Date().toISOString(),
+    };
+  }
+}
+
+module.exports = { DependencyHealthChecker };

--- a/src/sync/registry-mirror.js
+++ b/src/sync/registry-mirror.js
@@ -1,0 +1,107 @@
+const axios = require("axios");
+const fs = require("fs");
+const path = require("path");
+
+const NPM_REGISTRY = "https://registry.npmjs.org";
+const MIRROR_DIR = process.env.MIRROR_CACHE_DIR || "/tmp/registry-mirror";
+
+/**
+ * Mirrors package tarballs locally for air-gapped or CI environments.
+ * Downloads .tgz files for pinned dependency versions.
+ */
+class RegistryMirror {
+  constructor(opts = {}) {
+    this.registryUrl = opts.registryUrl || NPM_REGISTRY;
+    this.cacheDir = opts.cacheDir || MIRROR_DIR;
+    this.httpClient = axios.create({
+      baseURL: this.registryUrl,
+      timeout: 30_000,
+      responseType: "json",
+    });
+
+    if (!fs.existsSync(this.cacheDir)) {
+      fs.mkdirSync(this.cacheDir, { recursive: true });
+    }
+  }
+
+  /**
+   * Fetch package metadata from the registry.
+   */
+  async fetchPackageMetadata(packageName) {
+    const response = await this.httpClient.get(
+      `/${encodeURIComponent(packageName)}`
+    );
+    return response.data;
+  }
+
+  /**
+   * Download a specific version tarball to the local mirror.
+   */
+  async downloadTarball(packageName, version) {
+    const metadata = await this.fetchPackageMetadata(packageName);
+    const versionData = metadata.versions?.[version];
+    if (!versionData) {
+      throw new Error(`Version ${version} not found for ${packageName}`);
+    }
+
+    const tarballUrl = versionData.dist.tarball;
+    const integrity = versionData.dist.integrity || versionData.dist.shasum;
+
+    const tarballResponse = await axios.get(tarballUrl, {
+      responseType: "arraybuffer",
+      timeout: 60_000,
+    });
+
+    const outDir = path.join(this.cacheDir, packageName);
+    if (!fs.existsSync(outDir)) {
+      fs.mkdirSync(outDir, { recursive: true });
+    }
+
+    const outPath = path.join(outDir, `${version}.tgz`);
+    fs.writeFileSync(outPath, tarballResponse.data);
+
+    return {
+      package: packageName,
+      version,
+      path: outPath,
+      size: tarballResponse.data.length,
+      integrity,
+      mirroredAt: new Date().toISOString(),
+    };
+  }
+
+  /**
+   * Mirror all dependencies from a package.json file.
+   */
+  async mirrorFromPackageJson(pkgJsonPath) {
+    const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, "utf-8"));
+    const allDeps = {
+      ...pkg.dependencies,
+      ...pkg.devDependencies,
+    };
+
+    const results = [];
+    const failures = [];
+
+    for (const [name, versionRange] of Object.entries(allDeps)) {
+      const version = versionRange.replace(/^[\^~>=<]*/g, "");
+      try {
+        const result = await this.downloadTarball(name, version);
+        results.push(result);
+      } catch (err) {
+        failures.push({ package: name, version, error: err.message });
+      }
+    }
+
+    return {
+      mirrored: results.length,
+      failed: failures.length,
+      total: Object.keys(allDeps).length,
+      cacheDir: this.cacheDir,
+      results,
+      failures,
+    };
+  }
+}
+
+module.exports = { RegistryMirror };


### PR DESCRIPTION
## Summary

Adds three `axios`-powered HTTP client modules for vulnerability management tooling:

- **`src/clients/vulnerability-feed.js`** — Aggregates security advisories from OSV and NVD APIs, normalises them into a common format with severity, aliases, and timestamps
- **`src/health/dependency-checker.js`** — Queries the npm registry for each dependency to report outdated packages, deprecation status, license info, and an overall health score
- **`src/sync/registry-mirror.js`** — Downloads package tarballs to a local cache directory for air-gapped or CI environments

### `axios` usage locations
| File | Usage |
|------|-------|
| `src/clients/vulnerability-feed.js` | `axios.create()` instance for OSV POST + NVD GET with API key headers |
| `src/health/dependency-checker.js` | `axios.create()` instance hitting npm registry per-package |
| `src/sync/registry-mirror.js` | `axios.create()` for metadata + raw `axios.get()` for tarball binary downloads |