### PR TITLE
feat: add CVE normaliser, config validator, and summary report builder

### DIFF
--- a/src/config/schema-validator.js
+++ b/src/config/schema-validator.js
@@ -1,0 +1,142 @@
+const _ = require("lodash");
+
+/**
+ * Validates and normalises configuration objects against a schema.
+ * Uses lodash for deep defaults, path-based access, and type checking.
+ */
+
+const CONFIG_SCHEMA = {
+  server: {
+    port: { type: "number", default: 3000, min: 1, max: 65535 },
+    host: { type: "string", default: "0.0.0.0" },
+    cors: {
+      origins: { type: "array", default: ["*"] },
+      credentials: { type: "boolean", default: false },
+    },
+  },
+  integrations: {
+    github: {
+      token: { type: "string", required: true },
+      baseUrl: { type: "string", default: "https://api.github.com" },
+    },
+    jira: {
+      baseUrl: { type: "string" },
+      email: { type: "string" },
+      apiToken: { type: "string" },
+      projectKey: { type: "string", default: "SEC" },
+    },
+    slack: {
+      webhookUrl: { type: "string" },
+      channel: { type: "string", default: "#security-alerts" },
+    },
+  },
+  processing: {
+    batchSize: { type: "number", default: 50, min: 1, max: 500 },
+    concurrency: { type: "number", default: 10, min: 1, max: 100 },
+    timeout: { type: "number", default: 30000 },
+    retries: { type: "number", default: 3, min: 0, max: 10 },
+  },
+};
+
+/**
+ * Recursively flattens the schema into dot-notation paths.
+ */
+function flattenSchema(schema, prefix = "") {
+  return _.reduce(
+    schema,
+    (acc, value, key) => {
+      const fullPath = prefix ? `${prefix}.${key}` : key;
+      if (_.has(value, "type")) {
+        acc[fullPath] = value;
+      } else if (_.isPlainObject(value)) {
+        _.assign(acc, flattenSchema(value, fullPath));
+      }
+      return acc;
+    },
+    {}
+  );
+}
+
+/**
+ * Validates a config object against CONFIG_SCHEMA.
+ * Returns { valid, errors, config } where config has defaults applied.
+ */
+function validateConfig(rawConfig) {
+  const flat = flattenSchema(CONFIG_SCHEMA);
+  const errors = [];
+  const config = _.cloneDeep(rawConfig);
+
+  _.forEach(flat, (rule, path) => {
+    const value = _.get(config, path);
+
+    // Apply default if missing
+    if (_.isNil(value) && _.has(rule, "default")) {
+      _.set(config, path, rule.default);
+      return;
+    }
+
+    // Check required
+    if (rule.required && _.isNil(value)) {
+      errors.push({ path, message: `Required field "${path}" is missing` });
+      return;
+    }
+
+    // Skip optional missing fields
+    if (_.isNil(value)) return;
+
+    // Type check
+    const actualType = _.isArray(value) ? "array" : typeof value;
+    if (actualType !== rule.type) {
+      errors.push({
+        path,
+        message: `Expected ${rule.type} at "${path}", got ${actualType}`,
+      });
+      return;
+    }
+
+    // Range check for numbers
+    if (rule.type === "number") {
+      if (!_.isNil(rule.min) && value < rule.min) {
+        errors.push({ path, message: `"${path}" must be >= ${rule.min}` });
+      }
+      if (!_.isNil(rule.max) && value > rule.max) {
+        errors.push({ path, message: `"${path}" must be <= ${rule.max}` });
+      }
+    }
+  });
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    config,
+  };
+}
+
+/**
+ * Merges environment variables into config using a naming convention.
+ * E.g., CONFVE_SERVER_PORT=8080 → config.server.port = 8080
+ */
+function mergeEnvOverrides(config, env = process.env) {
+  const confveVars = _.pickBy(env, (_val, key) =>
+    _.startsWith(key, "CONFVE_")
+  );
+
+  _.forEach(confveVars, (value, key) => {
+    const path = key
+      .replace(/^CONFVE_/, "")
+      .toLowerCase()
+      .replace(/_/g, ".");
+
+    // Coerce types
+    let coerced = value;
+    if (value === "true") coerced = true;
+    else if (value === "false") coerced = false;
+    else if (/^\d+$/.test(value)) coerced = _.toNumber(value);
+
+    _.set(config, path, coerced);
+  });
+
+  return config;
+}
+
+module.exports = { validateConfig, mergeEnvOverrides, flattenSchema, CONFIG_SCHEMA };

--- a/src/reporting/summary-builder.js
+++ b/src/reporting/summary-builder.js
@@ -1,0 +1,127 @@
+const _ = require("lodash");
+
+/**
+ * Builds human-readable summary reports from CVE validation results.
+ * Uses lodash extensively for data aggregation, sorting, and templating.
+ */
+
+/**
+ * Generates a full validation summary from an array of validation results.
+ */
+function buildSummary(results) {
+  const total = _.size(results);
+  const bySeverity = _.countBy(results, (r) =>
+    _.get(r, "severity", "UNKNOWN").toUpperCase()
+  );
+  const byClassification = _.countBy(results, (r) =>
+    _.get(r, "classification", "UNCLASSIFIED")
+  );
+
+  // Group results by package ecosystem
+  const byEcosystem = _.groupBy(results, (r) => {
+    const purl = _.get(r, "packageUrl", "");
+    const match = purl.match(/^pkg:(\w+)\//);
+    return match ? match[1] : "unknown";
+  });
+
+  const ecosystemSummaries = _.mapValues(byEcosystem, (items, ecosystem) => ({
+    ecosystem,
+    count: _.size(items),
+    critical: _.filter(items, (i) => _.get(i, "severity") === "CRITICAL").length,
+    high: _.filter(items, (i) => _.get(i, "severity") === "HIGH").length,
+    fixable: _.filter(items, (i) =>
+      ["SAFE_PATCH", "MINOR_BUMP", "MAJOR_BUMP_SAFE"].includes(
+        _.get(i, "classification")
+      )
+    ).length,
+  }));
+
+  // Find most urgent items
+  const actionRequired = _.chain(results)
+    .filter((r) => ["CRITICAL", "HIGH"].includes(_.get(r, "severity", "").toUpperCase()))
+    .filter((r) =>
+      ["SAFE_PATCH", "MINOR_BUMP"].includes(_.get(r, "classification"))
+    )
+    .sortBy((r) => {
+      const order = { CRITICAL: 0, HIGH: 1 };
+      return _.get(order, _.get(r, "severity", "").toUpperCase(), 99);
+    })
+    .take(10)
+    .value();
+
+  // Confidence distribution
+  const confidences = _.compact(_.map(results, "confidence"));
+  const avgConfidence = _.isEmpty(confidences)
+    ? 0
+    : _.round(_.mean(confidences), 2);
+  const minConfidence = _.isEmpty(confidences) ? 0 : _.min(confidences);
+
+  return {
+    generatedAt: new Date().toISOString(),
+    overview: {
+      totalVulnerabilities: total,
+      bySeverity: _.defaults(bySeverity, {
+        CRITICAL: 0,
+        HIGH: 0,
+        MEDIUM: 0,
+        LOW: 0,
+      }),
+      byClassification,
+    },
+    ecosystems: ecosystemSummaries,
+    actionRequired: {
+      count: actionRequired.length,
+      items: actionRequired.map((r) => ({
+        id: _.get(r, "cveId"),
+        package: _.get(r, "packageUrl"),
+        severity: _.get(r, "severity"),
+        classification: _.get(r, "classification"),
+        fixVersion: _.get(r, "fixVersion"),
+      })),
+    },
+    confidence: {
+      average: avgConfidence,
+      minimum: minConfidence,
+      distribution: {
+        high: _.filter(confidences, (c) => c >= 0.8).length,
+        medium: _.filter(confidences, (c) => c >= 0.5 && c < 0.8).length,
+        low: _.filter(confidences, (c) => c < 0.5).length,
+      },
+    },
+  };
+}
+
+/**
+ * Renders the summary as a markdown string for Slack / PR comments.
+ */
+function renderMarkdown(summary) {
+  const ov = summary.overview;
+  const lines = [
+    `# Vulnerability Scan Summary`,
+    ``,
+    `**${ov.totalVulnerabilities}** vulnerabilities found | ` +
+      `**${_.get(ov.bySeverity, "CRITICAL", 0)}** critical | ` +
+      `**${_.get(ov.bySeverity, "HIGH", 0)}** high`,
+    ``,
+    `## By Classification`,
+    ..._.map(ov.byClassification, (count, cls) => `- **${cls}**: ${count}`),
+    ``,
+    `## Ecosystems`,
+    ..._.map(summary.ecosystems, (eco) =>
+      `- **${eco.ecosystem}**: ${eco.count} vulns (${eco.fixable} fixable)`
+    ),
+    ``,
+    `## Action Required (${summary.actionRequired.count})`,
+    ..._.map(summary.actionRequired.items, (item) =>
+      `- \`${item.id}\` in \`${item.package}\` — ${item.severity} / ${item.classification} → fix: ${item.fixVersion || "N/A"}`
+    ),
+    ``,
+    `---`,
+    `_Confidence: avg ${summary.confidence.average} | min ${summary.confidence.minimum}_`,
+    `_Generated: ${summary.generatedAt}_`,
+  ];
+
+  return _.join(lines, "\n");
+}
+
+module.exports = { buildSummary, renderMarkdown };

--- a/src/transforms/cve-normaliser.js
+++ b/src/transforms/cve-normaliser.js
@@ -1,0 +1,73 @@
+const _ = require("lodash");
+
+/**
+ * Normalises and deduplicates CVE records coming from multiple
+ * upstream feeds (OSV, NVD, GitHub Advisories). Heavily relies
+ * on lodash for deep merging, grouping, and safe property access.
+ */
+
+const SEVERITY_ORDER = ["CRITICAL", "HIGH", "MEDIUM", "LOW", "UNKNOWN"];
+
+/**
+ * Given an array of raw advisory objects from mixed sources,
+ * returns a deduplicated, merged, and severity-sorted array.
+ */
+function normaliseAdvisories(rawAdvisories) {
+  // Group by canonical CVE ID, falling back to advisory-specific ID
+  const grouped = _.groupBy(rawAdvisories, (adv) =>
+    _.get(adv, "aliases[0]", adv.id || adv.cveId || "unknown")
+  );
+
+  const merged = _.map(grouped, (advisories, cveId) => {
+    // Deep-merge all source records so no field is lost
+    const base = _.mergeWith({}, ...advisories, (objVal, srcVal) => {
+      if (_.isArray(objVal)) return _.uniq([...objVal, ...srcVal]);
+    });
+
+    // Pick the highest severity across sources
+    const severities = _.compact(_.map(advisories, "severity"));
+    const highestSeverity = _.minBy(severities, (s) =>
+      SEVERITY_ORDER.indexOf(s.toUpperCase())
+    );
+
+    return {
+      id: cveId,
+      severity: highestSeverity || "UNKNOWN",
+      sources: _.uniq(_.map(advisories, "source")),
+      summary: _.get(base, "summary", ""),
+      description: _.get(base, "description", _.get(base, "details", "")),
+      aliases: _.uniq(_.compact(_.flatten(_.map(advisories, "aliases")))),
+      affected: _.uniqBy(
+        _.flatten(_.map(advisories, "affected")),
+        (a) => `${_.get(a, "package.name")}@${_.get(a, "package.version")}`
+      ),
+      references: _.uniqBy(_.flatten(_.map(advisories, "references")), "url"),
+      cvss: _.get(base, "cvss", {}),
+      published: _.get(base, "published"),
+      modified: _.get(base, "modified"),
+    };
+  });
+
+  // Sort by severity — CRITICAL first
+  return _.sortBy(merged, (item) =>
+    SEVERITY_ORDER.indexOf((item.severity || "UNKNOWN").toUpperCase())
+  );
+}
+
+/**
+ * Computes a confidence score (0-1) based on source agreement.
+ */
+function computeConfidence(advisory) {
+  const sourceCount = _.size(_.get(advisory, "sources", []));
+  const hasCVSS = !_.isEmpty(_.get(advisory, "cvss"));
+  const hasDescription = !_.isEmpty(_.get(advisory, "summary"));
+
+  let score = 0;
+  score += _.clamp(sourceCount / 3, 0, 0.5); // up to 0.5 for 3+ sources
+  score += hasCVSS ? 0.3 : 0;
+  score += hasDescription ? 0.2 : 0;
+
+  return _.round(score, 2);
+}
+
+module.exports = { normaliseAdvisories, computeConfidence };


### PR DESCRIPTION
Add lodash-powered data processing utilities:
- src/transforms/cve-normaliser.js: deduplicates and merges advisories from multiple sources
- src/config/schema-validator.js: validates config against schema with defaults and env overrides
- src/reporting/summary-builder.js: builds severity/ecosystem summary reports with markdown output