### PR TITLE
[cveBump] bump form-data 4.0.0 → 4.0.4 (CVE-2025-7783)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"No tests configured\""
   },
   "dependencies": {
-    "form-data": "4.0.0",
+    "form-data": "^4.0.4",
     "axios": "1.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## cveBump Security Advisory

**CVE:** `CVE-2025-7783`  
**Package:** `form-data@4.0.0` → fix: `^4.0.4`  
**Risk Score:** `46.9 / 100` (MEDIUM)  
**SLA:** 14 days  

**Jira Ticket:** [ENG-950](https://go1web.atlassian.net/browse/ENG-950)  

### Exploit Preconditions

- com/hacking-the-javascript-lottery-80cc437e3b7f), an attacker who can observe a few sequential values can determine the state of the PRNG and predict future values, includes those used to generate form-data's boundary value.
- The allows the attacker to craft a value that contains a boundary value, allowing them to inject additional parameters into the request.
- An attacker who is able to predict the output of Math.

### Migration Steps

1. Update package.json: `form-data` version from `4.0.0` to `^4.0.4`.
2. Run the appropriate install command (e.g. `npm install` / `pip install -U`) to pull in the patched version.
3. No breaking API changes detected — no code modifications expected.
4. This is a patch-level bump; existing tests should pass without modification.

> Auto-generated by cveBump. Repo: https://github.com/ash3dwards/cveBump-test