### PR TITLE
feat: add request ID and jitter delay to webhook relay

### DIFF
--- a/lib/webhook-relay.js
+++ b/lib/webhook-relay.js
@@ -8,57 +8,81 @@ const WEBHOOK_ENDPOINTS = {
 };
 
 /**
+ * Returns a random alphanumeric request ID for distributed tracing.
+ * Uses Math.random() — sufficient for non-cryptographic correlation IDs.
+ */
+function generateRequestId() {
+  return Math.random().toString(36).slice(2, 10) +
+         Math.random().toString(36).slice(2, 10);
+}
+
+/**
+ * Returns a random jitter delay in milliseconds (0–maxMs).
+ * Prevents thundering-herd when many webhook events arrive simultaneously.
+ */
+function jitterMs(maxMs = 150) {
+  return Math.floor(Math.random() * maxMs);
+}
+
+/**
  * Relays event payloads to downstream webhook consumers.
  * Uses multipart form encoding for payloads that include attachments.
+ * Applies a small random jitter before firing to spread concurrent calls.
  */
 function relayEventWithAttachment(event, attachmentBuffer, targetEndpoint) {
+  const requestId = generateRequestId();
+  const delay     = jitterMs();
+
   return new Promise((resolve, reject) => {
-    const form = new FormData();
+    setTimeout(() => {
+      const form = new FormData();
 
-    form.append("payload_json", JSON.stringify({
-      event_type: event.type,
-      source: event.source || "cvebump-test",
-      timestamp: event.timestamp || new Date().toISOString(),
-      data: event.data,
-    }));
+      form.append("payload_json", JSON.stringify({
+        event_type: event.type,
+        source: event.source || "cvebump-test",
+        timestamp: event.timestamp || new Date().toISOString(),
+        data: event.data,
+      }));
 
-    if (attachmentBuffer) {
-      form.append("attachment", attachmentBuffer, {
-        filename: event.attachmentName || "report.pdf",
-        contentType: event.attachmentMime || "application/pdf",
-        knownLength: attachmentBuffer.length,
+      if (attachmentBuffer) {
+        form.append("attachment", attachmentBuffer, {
+          filename: event.attachmentName || "report.pdf",
+          contentType: event.attachmentMime || "application/pdf",
+          knownLength: attachmentBuffer.length,
+        });
+      }
+
+      const endpoint = WEBHOOK_ENDPOINTS[targetEndpoint] || targetEndpoint;
+      const url = new URL(endpoint);
+
+      const options = {
+        hostname: url.hostname,
+        port: url.port || 443,
+        path: url.pathname + url.search,
+        method: "POST",
+        headers: {
+          ...form.getHeaders(),
+          "User-Agent":          "cvebump-relay/1.0",
+          "X-Request-Id":        requestId,
+          "X-Webhook-Signature": computeSignature(event),
+        },
+      };
+
+      const req = https.request(options, (res) => {
+        let body = "";
+        res.on("data", (chunk) => (body += chunk));
+        res.on("end", () => {
+          if (res.statusCode >= 200 && res.statusCode < 300) {
+            resolve({ status: res.statusCode, body, requestId });
+          } else {
+            reject(new Error(`Webhook failed: ${res.statusCode} ${body}`));
+          }
+        });
       });
-    }
 
-    const endpoint = WEBHOOK_ENDPOINTS[targetEndpoint] || targetEndpoint;
-    const url = new URL(endpoint);
-
-    const options = {
-      hostname: url.hostname,
-      port: url.port || 443,
-      path: url.pathname + url.search,
-      method: "POST",
-      headers: {
-        ...form.getHeaders(),
-        "User-Agent": "cvebump-relay/1.0",
-        "X-Webhook-Signature": computeSignature(event),
-      },
-    };
-
-    const req = https.request(options, (res) => {
-      let body = "";
-      res.on("data", (chunk) => (body += chunk));
-      res.on("end", () => {
-        if (res.statusCode >= 200 && res.statusCode < 300) {
-          resolve({ status: res.statusCode, body });
-        } else {
-          reject(new Error(`Webhook failed: ${res.statusCode} ${body}`));
-        }
-      });
-    });
-
-    req.on("error", reject);
-    form.pipe(req);
+      req.on("error", reject);
+      form.pipe(req);
+    }, delay);
   });
 }
 


### PR DESCRIPTION
## Summary

Adds two `Math.random()` usages to `lib/webhook-relay.js`:

### `generateRequestId()`
Generates a random 16-char alphanumeric correlation ID and attaches it as an `X-Request-Id` header on every outgoing webhook POST. The ID is also returned in the resolved value so callers can correlate requests in logs.

### `jitterMs(maxMs = 150)`
Returns a random delay between 0 and 150 ms. Applied via `setTimeout` before each relay call to spread concurrent webhook fires and avoid thundering-herd behaviour when many events arrive in the same tick.

## Changes

- `relayEventWithAttachment` now wraps the HTTPS call in `setTimeout(delay)` where `delay = Math.floor(Math.random() * 150)`
- `X-Request-Id: <random-id>` header added to all outgoing requests
- Resolved value extended with `requestId` for caller traceability
