### PR TITLE
[cveBump] bump form-data 4.0.0 → 4.0.4 (CVE-2025-7783)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"No tests configured\""
   },
   "dependencies": {
-    "form-data": "4.0.0",
+    "form-data": "^4.0.4",
     "axios": "1.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## cveBump Security Advisory

**CVE:** `CVE-2025-7783`  
**Package:** `form-data@4.0.0` → fix: `^4.0.4`  
**Risk Score:** `51.4 / 100` (HIGH)  
**SLA:** 7 days  

**Jira Ticket:** [ENG-957](https://go1web.atlassian.net/browse/ENG-957)  

### Exploit Preconditions

- com/hacking-the-javascript-lottery-80cc437e3b7f), an attacker who can observe a few sequential values can determine the state of the PRNG and predict future values, includes those used to generate form-data's boundary value.
- The allows the attacker to craft a value that contains a boundary value, allowing them to inject additional parameters into the request.
- An attacker who is able to predict the output of Math.

### Migration Steps

1. Update package.json: `form-data` version from `4.0.0` to `^4.0.4`.
2. Run the appropriate install command (e.g. `npm install` / `pip install -U`) to pull in the patched version.
3. No breaking API changes detected — no code modifications expected.
4. This is a patch-level bump; existing tests should pass without modification.

### Release Notes — [v4.0.4](https://github.com/form-data/form-data/releases/tag/v4.0.4)

**Released:** 2025-07-24  
**Breaking Change Classification:** `None` | **Upgrade Complexity:** `0.02`  



```
## [v4.0.4](https://github.com/form-data/form-data/compare/v4.0.3...v4.0.4) - 2025-07-16

### Commits

- [meta] add `auto-changelog` [`811f682`](https://github.com/form-data/form-data/commit/811f68282fab0315209d0e2d1c44b6c32ea0d479)
- [Tests] handle predict-v8-randomness failures in node &lt; 17 and node &gt; 23 [`1d11a76`](https://github.com/form-data/form-data/commit/1d11a76434d101f22fdb26b8aef8615f28b98402)
- [Fix] Switch to using `crypto` random for boundary values [`3d17230`](https://github.com/form-data/form-data/commit/3d1723080e6577a66f17f163ecd345a21d8d0fd0)
- [Tests] fix linti…
```

### Reachability — Usage Sites *(analysis: combined)*

| File | Line | Context |
|---|---|---|
| `` | 0 | `` |

> Auto-generated by cveBump. Repo: https://github.com/ash3dwards/cveBump-test