### PR TITLE
[cveBump] bump axios 1.6.0 → 1.13.5 (CVE-2026-25639)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "form-data": "4.0.0",
-    "axios": "1.6.0"
+    "axios": "^1.13.5"
   },
   "devDependencies": {
     "lodash": "4.17.20"


### PR DESCRIPTION
## cveBump Security Advisory

**CVE:** `CVE-2026-25639`  
**GHSA:** `GHSA-43fc-jf86-j433`  
**Repository:** https://github.com/ash3dwards/cveBump-test  
**Package:** `axios@1.6.0` → fix: `^1.13.5`  
**Risk Score:** `37.75 / 100` (MEDIUM)  
**Overall Confidence:** `0.7` (threshold: `0.88` — standard)  
**Patch Fast-Path:** no  
**SLA:** 30 days  

**Jira Ticket:** [ENG-963](https://go1web.atlassian.net/browse/ENG-963)  

### Exploit Preconditions

- An attacker can trigger this by providing a malicious configuration object created via `JSON.

### Migration Steps

1. Update package.json: `axios` version from `1.6.0` to `^1.13.5`.
2. Run the appropriate install command (e.g. `npm install` / `pip install -U`) to pull in the patched version.
3. No breaking API changes detected — no code modifications expected.
4. Minor version bump — new features may be available; existing behaviour preserved.

### Release Notes — [v1.13.5](https://github.com/axios/axios/releases/tag/v1.13.5)

**Released:** 2026-02-08  
**Breaking Change Classification:** `Low` | **Upgrade Complexity:** `0.05`  



```
## Release 1.13.5

### Highlights
- **Security:** Fixed a potential **Denial of Service** issue involving the `__proto__` key in `mergeConfig`. (PR [#7369](https://github.com/axios/axios/pull/7369))
- **Bug fix:** Resolved an issue where `AxiosError` could be missing the `status` field on and after **v1.13.3**. (PR [#7368](https://github.com/axios/axios/pull/7368))

### Changes

#### Security
- Fix Denial of Service via `__proto__` key in `mergeConfig`. (PR [#7369](https://github.com/axios/axios/pull/7369))

#### Fixes
- Fix/5657. (PR [#7313](https://github.com/axios/axios/pull/731…
```

### Reachability — Usage Sites *(analysis: combined)*

*No direct symbol usage sites found via CodeGraph.*

> Auto-generated by cveBump.