### PR TITLE
[cveBump] bump axios 1.6.0 → 1.12.0 (CVE-2025-58754)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "form-data": "4.0.0",
-    "axios": "1.6.0"
+    "axios": "^1.12.0"
   },
   "devDependencies": {
     "lodash": "4.17.20"


### PR DESCRIPTION
## cveBump Security Advisory

**CVE:** `CVE-2025-58754`  
**GHSA:** `GHSA-4hjh-wcwx-xvwj`  
**Repository:** https://github.com/ash3dwards/cveBump-test  
**Package:** `axios@1.6.0` → fix: `^1.12.0`  
**Risk Score:** `37.75 / 100` (MEDIUM)  
**Overall Confidence:** `0.7` (threshold: `0.88` — standard)  
**Patch Fast-Path:** no  
**SLA:** 30 days  

**Jira Ticket:** [ENG-964](https://go1web.atlassian.net/browse/ENG-964)  

### Exploit Preconditions

- This path ignores `maxContentLength` / `maxBodyLength` (which only protect HTTP responses), so an attacker can supply a very large `data:` URI and cause the process to allocate unbounded memory and crash (DoS), even if the caller requested `responseType: 'stream'`.

### Migration Steps

1. Update package.json: `axios` version from `1.6.0` to `^1.12.0`.
2. Run the appropriate install command (e.g. `npm install` / `pip install -U`) to pull in the patched version.
3. No breaking API changes detected — no code modifications expected.
4. Minor version bump — new features may be available; existing behaviour preserved.

### Release Notes — [v1.12.0](https://github.com/axios/axios/releases/tag/v1.12.0)

**Released:** 2025-09-11  
**Breaking Change Classification:** `None` | **Upgrade Complexity:** `0.05`  



```
## Release notes:
### Bug Fixes

* adding build artifacts ([9ec86de](https://github.com/axios/axios/commit/9ec86de257bfa33856571036279169f385ed92bd))
* dont add dist on release ([a2edc36](https://github.com/axios/axios/commit/a2edc3606a4f775d868a67bb3461ff18ce7ecd11))
* **fetch-adapter:** set correct Content-Type for Node FormData ([#6998](https://github.com/axios/axios/issues/6998)) ([a9f47af](https://github.com/axios/axios/commit/a9f47afbf3224d2ca987dbd8188789c7ea853c5d))
* **node:** enforce maxContentLength for data: URLs ([#7011](https://github.com/axios/axios/issues/7011)) ([945435f](http…
```

### Reachability — Usage Sites *(analysis: combined)*

*No direct symbol usage sites found via CodeGraph.*

> Auto-generated by cveBump.