### PR TITLE
[cveBump] bump axios 1.6.0 → 1.7.4 (CVE-2024-39338)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "form-data": "4.0.0",
-    "axios": "1.6.0"
+    "axios": "^1.7.4"
   },
   "devDependencies": {
     "lodash": "4.17.20"


### PR DESCRIPTION
## cveBump Security Advisory

**CVE:** `CVE-2024-39338`  
**GHSA:** `GHSA-8hc4-vh64-cxmj`  
**Repository:** https://github.com/ash3dwards/cveBump-test  
**Package:** `axios@1.6.0` → fix: `^1.7.4`  
**Risk Score:** `47.75 / 100` (MEDIUM)  
**Overall Confidence:** `0.7` (threshold: `0.88` — standard)  
**Patch Fast-Path:** no  
**SLA:** 30 days  

**Jira Ticket:** [ENG-965](https://go1web.atlassian.net/browse/ENG-965)  

### Exploit Preconditions

- Refer to advisory GHSA-8hc4-vh64-cxmj for exploit preconditions.

### Migration Steps

1. Update package.json: `axios` version from `1.6.0` to `^1.7.4`.
2. Run the appropriate install command (e.g. `npm install` / `pip install -U`) to pull in the patched version.
3. No breaking API changes detected — no code modifications expected.
4. Minor version bump — new features may be available; existing behaviour preserved.

### Release Notes — [v1.7.4](https://github.com/axios/axios/releases/tag/v1.7.4)

**Released:** 2024-08-13  
**Breaking Change Classification:** `None` | **Upgrade Complexity:** `0.05`  



```
## Release notes:
### Bug Fixes

* **sec:** CVE-2024-39338 ([#6539](https://github.com/axios/axios/issues/6539)) ([#6543](https://github.com/axios/axios/issues/6543)) ([6b6b605](https://github.com/axios/axios/commit/6b6b605eaf73852fb2dae033f1e786155959de3a))
* **sec:** disregard protocol-relative URL to remediate SSRF ([#6539](https://github.com/axios/axios/issues/6539)) ([07a661a](https://github.com/axios/axios/commit/07a661a2a6b9092c4aa640dcc7f724ec5e65bdda))

### Contributors to this release

- <img src="https://avatars.githubusercontent.com/u/31389480?v&#x3D;4&amp;s&#x3D;18" alt="avatar" w…
```

### Reachability — Usage Sites *(analysis: combined)*

| File | Line | Context |
|---|---|---|
| `` | 0 | `` |
| `` | 0 | `` |
| `` | 0 | `` |
| `` | 0 | `` |
| `` | 0 | `` |

> Auto-generated by cveBump.