### PR TITLE
[cveBump] bump axios 1.6.0 → 1.8.2 (CVE-2025-27152)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "form-data": "4.0.0",
-    "axios": "1.6.0"
+    "axios": "^1.8.2"
   },
   "devDependencies": {
     "lodash": "4.17.20"


### PR DESCRIPTION
## cveBump Security Advisory

**CVE:** `CVE-2025-27152`  
**GHSA:** `GHSA-jr5f-v2jv-69x6`  
**Repository:** https://github.com/ash3dwards/cveBump-test  
**Package:** `axios@1.6.0` → fix: `^1.8.2`  
**Risk Score:** `44.45 / 100` (MEDIUM)  
**Overall Confidence:** `0.7` (threshold: `0.88` — standard)  
**Patch Fast-Path:** no  
**SLA:** 30 days  

**Jira Ticket:** [ENG-966](https://go1web.atlassian.net/browse/ENG-966)  

### Exploit Preconditions

- const userId = "http://attacker.
- In this example, the request is sent to `http://attacker.
- As a result, the domain owner of `attacker.

### Migration Steps

1. Update package.json: `axios` version from `1.6.0` to `^1.8.2`.
2. Run the appropriate install command (e.g. `npm install` / `pip install -U`) to pull in the patched version.
3. No breaking API changes detected — no code modifications expected.
4. Minor version bump — new features may be available; existing behaviour preserved.

### Release Notes — [v1.8.2](https://github.com/axios/axios/releases/tag/v1.8.2)

**Released:** 2025-03-07  
**Breaking Change Classification:** `None` | **Upgrade Complexity:** `0.05`  



```
## Release notes:
### Bug Fixes

* **http-adapter:** add allowAbsoluteUrls to path building ([#6810](https://github.com/axios/axios/issues/6810)) ([fb8eec2](https://github.com/axios/axios/commit/fb8eec214ce7744b5ca787f2c3b8339b2f54b00f))

### Contributors to this release

- <img src="https://avatars.githubusercontent.com/u/14166260?v&#x3D;4&amp;s&#x3D;18" alt="avatar" width="18"/> [Fasoro-Joseph Alexander](https://github.com/lexcorp16 "+1/-1 (#6810 )")
```

### Reachability — Usage Sites *(analysis: combined)*

| File | Line | Context |
|---|---|---|
| `` | 0 | `` |
| `` | 0 | `` |
| `` | 0 | `` |
| `` | 0 | `` |
| `` | 0 | `` |

> Auto-generated by cveBump.