### PR TITLE
[cveBump] bump lodash 4.17.20 → 4.17.21 (CVE-2020-28500)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
     "axios": "1.6.0"
   },
   "devDependencies": {
-    "lodash": "4.17.20"
+    "lodash": "^4.17.21"
   }
 }


### PR DESCRIPTION
## cveBump Security Advisory

**CVE:** `CVE-2020-28500`  
**GHSA:** `GHSA-29mw-wpgm-hmr9`  
**Repository:** https://github.com/ash3dwards/cveBump-test  
**Package:** `lodash@4.17.20` → fix: `^4.17.21`  
**Risk Score:** `27.05 / 100` (MEDIUM)  
**Overall Confidence:** `0.75` (threshold: `0.75` — patch fast-path active)  
**Patch Fast-Path:** ✅ yes  
**SLA:** 30 days  

**Jira Ticket:** [ENG-968](https://go1web.atlassian.net/browse/ENG-968)  

### Exploit Preconditions

- Refer to advisory GHSA-29mw-wpgm-hmr9 for exploit preconditions.

### Migration Steps

1. Update package.json: `lodash` version from `4.17.20` to `^4.17.21`.
2. Run the appropriate install command (e.g. `npm install` / `pip install -U`) to pull in the patched version.
3. No breaking API changes detected — no code modifications expected.
4. This is a patch-level bump; existing tests should pass without modification.

### Release Notes — v4.17.21

**Released:** 2025-07-24  
**Breaking Change Classification:** `None` | **Upgrade Complexity:** `0.02`  



*See release page for details.*

### Reachability — Usage Sites *(analysis: combined)*

| File | Line | Context |
|---|---|---|
| `` | 0 | `` |
| `` | 0 | `` |
| `` | 0 | `` |
| `` | 0 | `` |
| `` | 0 | `` |
| `` | 0 | `` |

> Auto-generated by cveBump.