### PR TITLE
[cveBump] bump lodash 4.17.20 → 4.17.23 (CVE-2025-13465)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
     "axios": "1.6.0"
   },
   "devDependencies": {
-    "lodash": "4.17.20"
+    "lodash": "^4.17.23"
   }
 }


### PR DESCRIPTION
## cveBump Security Advisory

**CVE:** `CVE-2025-13465`  
**GHSA:** `GHSA-xxjr-mmjv-4gpg`  
**Repository:** https://github.com/ash3dwards/cveBump-test  
**Package:** `lodash@4.17.20` → fix: `^4.17.23`  
**Risk Score:** `32.65 / 100` (MEDIUM)  
**Overall Confidence:** `0.75` (threshold: `0.75` — patch fast-path active)  
**Patch Fast-Path:** ✅ yes  
**SLA:** 30 days  

**Jira Ticket:** [ENG-969](https://go1web.atlassian.net/browse/ENG-969)  

### Exploit Preconditions

- An attacker can pass crafted paths which cause Lodash to delete methods from global prototypes.

### Migration Steps

1. Update package.json: `lodash` version from `4.17.20` to `^4.17.23`.
2. Run the appropriate install command (e.g. `npm install` / `pip install -U`) to pull in the patched version.
3. No breaking API changes detected — no code modifications expected.
4. This is a patch-level bump; existing tests should pass without modification.

### Release Notes — v4.17.23

**Released:** 2025-07-24  
**Breaking Change Classification:** `None` | **Upgrade Complexity:** `0.02`  



*See release page for details.*

### Reachability — Usage Sites *(analysis: combined)*

| File | Line | Context |
|---|---|---|
| `` | 0 | `` |
| `` | 0 | `` |
| `` | 0 | `` |
| `` | 0 | `` |
| `` | 0 | `` |
| `` | 0 | `` |

> Auto-generated by cveBump.